### PR TITLE
web-serving: Apply workaround for mysql on overlayfs

### DIFF
--- a/benchmarks/web-serving/db_server/bootstrap.sh
+++ b/benchmarks/web-serving/db_server/bootstrap.sh
@@ -7,6 +7,10 @@ fi
 
 WEB_SERVER_IP=$1
 
+# workaround for overlayfs:
+# https://docs.docker.com/engine/userguide/storagedriver/overlayfs-driver/#limitations-on-overlayfs-compatibility
+find /var/lib/mysql -type f -exec touch {} \;
+
 # Update the hostname/IP to that of the webserver
 sed -i -e"s/HOST_IP/${WEB_SERVER_IP}:8080/" /elgg_db.dump
 chmod a+x /execute.sh


### PR DESCRIPTION
Database container under web-serving benchmark fails to start mysqld on
startup with below error message when it uses overlayfs.
```
[ERROR] Fatal error: Can't open and lock privilege tables: Got error 140
from storage engine
```

The problem comes from POSIX break of overlayfs[1].  There is well known
two workarounds[2] for this problem.  1) add /var/lib/mysql volume, 2) touch
files under /var/lib/mysql once.  Because first workaround makes
unnecessary volume and second workaround is documented in Docker
official document, second workaround would be better.  This commit
applies the workaround.

[1] https://github.com/docker/for-linux/issues/72
[2] https://github.com/docker/for-linux/issues/72#issuecomment-319904698
[3]
https://docs.docker.com/engine/userguide/storagedriver/overlayfs-driver/#limitations-on-overlayfs-compatibility

Signed-off-by: SeongJae Park <sj38.park@gmail.com>