### PR TITLE
Missing end quote.

### DIFF
--- a/benchmarks/web-search/server/docker-entrypoint.sh
+++ b/benchmarks/web-search/server/docker-entrypoint.sh
@@ -15,7 +15,7 @@ wget -O - $INDEX_URL \
   | tar zxvf - -C $SOLR_CORE_DIR/cloudsuite_web_search*
 
 echo "================================="
-echo "Index Node IP Address: "`ifconfig eth0 2>/dev/null|awk '/inet addr:/ {print $2}'|sed 's/addr://'`
+echo "Index Node IP Address: "`ifconfig eth0 2>/dev/null|awk '/inet addr:/ {print $2}'|sed 's/addr://'`"
 echo "================================="
   
 #Run Solr  


### PR DESCRIPTION
The index node IP address doesn't get echo'd to stdout due to interpolation /missing double quote.