### PR TITLE
Integrated HHVM as a configurable option to the web-serving application.

### DIFF
--- a/benchmarks/web-serving/web_server/Dockerfile
+++ b/benchmarks/web-serving/web_server/Dockerfile
@@ -3,13 +3,19 @@ MAINTAINER Nooshin Mirzadeh <nooshin.mirzadeh@epfl.ch>
 
 USER root
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && \
+	apt-get install -y --force-yes software-properties-common && \
+	apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449 && \
+	add-apt-repository "deb http://dl.hhvm.com/ubuntu $(lsb_release -sc) main" && \
+	apt-get update && \
+	apt-get install --force-yes -y \
 	build-essential \
 	git \
 	nginx \
 	php5 php5-gd \
 	php5-mysql php5-curl \
-	php5-fpm php5-memcache	
+	php5-fpm php5-memcache \
+	hhvm
 
 # Increase the open file limit
 COPY files/limits.conf.append /tmp/
@@ -28,7 +34,10 @@ RUN chmod a+rw /elgg_data
 
 # Copy over the Nginx Server configuration
 COPY files/nginx_sites_avail.append /tmp/
-RUN cat /tmp/nginx_sites_avail.append >> /etc/nginx/sites-available/default
+
+# Copy over the Nginx HHVM Server configuration
+COPY files/nginx_sites_avail_hhvm.append /tmp/
+COPY files/configure_hhvm.sh /tmp/
 
 RUN service nginx restart
 
@@ -41,3 +50,4 @@ RUN chmod 700 /etc/bootstrap.sh
 EXPOSE 8080
 
 CMD ["/etc/bootstrap.sh", "-d"]
+

--- a/benchmarks/web-serving/web_server/bootstrap.sh
+++ b/benchmarks/web-serving/web_server/bootstrap.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
-
-
 DB_SERVER_IP=${1:-"mysql_server"}
 MEMCACHE_SERVER_IP=${2:-"memcache_server"}
 sed -i -e"s/mysql_server/${DB_SERVER_IP}/" elgg/engine/settings.php
 sed -i -e"s/'memcache_server'/'${MEMCACHE_SERVER_IP}'/" elgg/engine/settings.php
 
 
-FPM_CHILDREN=${3:-80}
-sed -i -e"s/pm.max_children = 5/pm.max_children = ${FPM_CHILDREN}/" /etc/php5/fpm/pool.d/www.conf
+if [[ ! -z "${HHVM}" && "${HHVM}" = "true" ]]; then
+	chmod 700 /tmp/configure_hhvm.sh
+	/tmp/configure_hhvm.sh
+else
+	cat /tmp/nginx_sites_avail.append >> /etc/nginx/sites-available/default
+	FPM_CHILDREN=${3:-80}
+	sed -i -e"s/pm.max_children = 5/pm.max_children = ${FPM_CHILDREN}/" /etc/php5/fpm/pool.d/www.conf
 
-service php5-fpm restart
+	service php5-fpm restart
+fi
+
 service nginx restart
 bash
+

--- a/benchmarks/web-serving/web_server/files/configure_hhvm.sh
+++ b/benchmarks/web-serving/web_server/files/configure_hhvm.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+update-rc.d hhvm defaults
+cat /etc/nginx/sites-enabled/default ~/nginx_backup
+cat /tmp/nginx_sites_avail_hhvm.append >> /etc/nginx/sites-available/default
+/usr/share/hhvm/install_fastcgi.sh
+echo "hhvm.server.allow_run_as_root = true" >> /etc/hhvm/server.ini
+/usr/bin/hhvm --config /etc/hhvm/php.ini --config /etc/hhvm/server.ini --mode daemon -vPidFile=/var/run/hhvm/pid
+

--- a/benchmarks/web-serving/web_server/files/nginx_sites_avail_hhvm.append
+++ b/benchmarks/web-serving/web_server/files/nginx_sites_avail_hhvm.append
@@ -1,0 +1,44 @@
+server {
+        listen 8080;
+        server_name localhost;
+        listen [::]:8080 default_server ipv6only=on;
+
+        root /usr/share/nginx/html/elgg;
+                # Server root, replace it with your elgg installation location
+                index index.php index.html index.htm;
+
+                # Server logs, replace it with your project names
+                error_log /var/log/nginx/example_error.log;
+                access_log /var/log/nginx/example_access.log;
+
+                location ~ (^\.|/\.) {
+                        return 403;
+                }
+
+                location /cache {
+                        rewrite ^/cache\/(.*)$ /engine/handlers/cache_handler.php?request=$1&$query_string;
+                }
+
+                location /export {
+                        rewrite ^/export\/([A-Za-z]+)\/([0-9]+)\/?$ /engine/handlers/export_handler.php?view=$1&guid=$2;
+                        rewrite ^/export\/([A-Za-z]+)\/([0-9]+)\/([A-Za-z]+)\/([A-Za-z0-9\_]+)\/$ /engine/handlers/export_handler.php?view=$1&guid=$2&type=$3&idname=$4;
+                }
+
+                location = /rewrite.php {
+                        rewrite ^(.*)$ /install.php;
+                }
+
+                location / {
+                        try_files $uri $uri/ /index.php?__elgg_uri=$uri&$query_string;
+                }
+
+                # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+                #
+               	# location ~ \.(hh|php)$ {
+                #    fastcgi_keep_conn on;
+                #    fastcgi_pass   127.0.0.1:9000;
+                #    fastcgi_index  index.php;
+                #    fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;
+                #    include        fastcgi_params;
+                #}                
+        }


### PR DESCRIPTION
The following command will start the web server(without HHVM):
$ docker run -dt --net=host --name=web_server cloudsuite/web-serving:web_server /etc/bootstrap.sh ${DATABASE_SERVER_IP} ${MEMCACHED_SERVER_IP} ${MAX_PM_CHILDREN}

The following command will start the web server (with HHVM enabled):
docker run -e "HHVM=true" -dt --net=host --name=web_server_local cloudsuite/web-serving:web_server /etc/bootstrap.sh ${DATABASE_SERVER_IP} ${MEMCACHED_SERVER_IP} ${MAX_PM_CHILDREN}