### PR TITLE
curl: command not found in web-search client Dockerfile

### DIFF
--- a/benchmarks/web-search/client/Dockerfile
+++ b/benchmarks/web-search/client/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Javier Picorel <javier.picorel@epfl.ch>
 ENV FABAN_USER faban
 
 RUN apt-get update -y \
-	&& apt-get install -y --no-install-recommends telnet wget tar \
+	&& apt-get install -y --no-install-recommends telnet wget tar curl \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& groupadd -r $FABAN_USER  \
 	&& useradd -r -g $FABAN_USER $FABAN_USER


### PR DESCRIPTION
Client container under web-search benchmark fails to start with below error message

```
./entrypoint.sh: line 42: curl: command not found
./entrypoint.sh: line 42: curl: command not found
./entrypoint.sh: line 42: curl: command not found
./entrypoint.sh: line 42: curl: command not found
./entrypoint.sh: line 42: curl: command not found
```

https://github.com/parsa-epfl/cloudsuite/issues/124
