### PR TITLE
Fixed displaying of IP address by data-serving server

### DIFF
--- a/benchmarks/data-serving/server/docker-entrypoint.sh
+++ b/benchmarks/data-serving/server/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo Server IP
-ifconfig eth0 2>/dev/null | awk '/inet addr:/ {print $2}' | sed 's/addr://'
+hostname --ip-address
 
 if [ -z "$CASSANDRA_SEEDS" ]; then
     NEED_INIT=1


### PR DESCRIPTION
The IP Address of the server wasn't displayed properly since the ifconfig command is no longer available. Change the command to hostname to fix the issue. 