### PR TITLE
Fix JAVA_HOME, issue #297

### DIFF
--- a/.github/scripts/build-images.sh
+++ b/.github/scripts/build-images.sh
@@ -55,10 +55,15 @@ if (grep -q "${DF_PATH#./}" <<<$modified_files) || # Rebuild the image if any fi
         DO_PUSH="--push"
     fi
     
-    if ([ $image_name = "debian" ]); then
+    if ([ $image_name = "debian" ] || [ $IMG_TAG = "openjdk11" ]); then
         cd $DF_PATH
         for arch in amd64 arm64 riscv64; do 
-            docker buildx build --platform=linux/${arch} -t $DH_REPO:${arch} -f Dockerfile.${arch} $DO_PUSH .             
+            if [ $IMG_TAG = "openjdk11" ]; then
+                docker buildx build --platform=linux/${arch} -t $DH_REPO:${arch} -f Dockerfile --build-arg EXTERNAL_ARG="/usr/lib/jvm/java-11-openjdk-${arch}/" $DO_PUSH .
+            else
+                docker buildx build --platform=linux/${arch} -t $DH_REPO:${arch} -f Dockerfile.${arch} $DO_PUSH . 
+            fi
+
             if [ $? != "0" ]; then
                 exit 1
             fi

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -14,7 +14,7 @@ env:
   PR_COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
   DOCKER_USER: ${{ secrets.DOCKER_HUB_USERNAME }}
   DOCKER_PASS: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-  FORCE_PUSH: "false"
+  FORCE_PUSH: "true"
 
 jobs:
   base-os:
@@ -32,6 +32,8 @@ jobs:
           fetch-depth: 0
       - name: build and push
         run: "./.github/scripts/build-images.sh"
+        env:
+          IMG_TAG: ${{ github.job }}
       - id: set_is_parent_modified
         run: echo "::set-output name=is_parent_modified::${MODIFIED}"
       

--- a/commons/java/openjdk11/Dockerfile
+++ b/commons/java/openjdk11/Dockerfile
@@ -2,5 +2,7 @@ FROM cloudsuitetest/debian:base-os
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends openjdk-11-jdk-headless \
         && rm -rf /var/lib/apt/lists/*
-# TODO: Fix this link for other architectures.
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/
+
+ARG EXTERNAL_ARG
+ENV JAVA_HOME=${EXTERNAL_ARG}
+RUN echo ${JAVA_HOME}


### PR DESCRIPTION
This PR addresses the issue mentioned in #297. 
Instead of having different Dockerfiles, the value on the environment variable is passed inside the build script and different images are finally manifested as a single image that is pushed to the repo. 
To avoid code replication, the implementation is consolidated by sharing code between `debian` and `openjdk11` images that both use a similar build mechanism. 