### PR TITLE
Add explicit tags for facebook workload and dataset

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -418,7 +418,7 @@ jobs:
       DH_REPO: "cloudsuitetest/${{ github.job }}"
     strategy:
       matrix:
-        tag: ["latest"]
+        tag: ["4.0"]
         platform: ["linux/amd64"]
     steps:
       - name: checkout
@@ -561,7 +561,7 @@ jobs:
       DH_REPO: "cloudsuitetest/${{ github.job }}"
     strategy:
       matrix:
-        tag: ["latest"]
+        tag: ["4.0"]
         platform: ["linux/amd64"]
     steps:
       - name: checkout
@@ -584,7 +584,7 @@ jobs:
       DH_REPO: "cloudsuitetest/${{ github.job }}"
     strategy:
       matrix:
-        tag: ["latest"]
+        tag: ["4.0"]
         platform: ["linux/amd64"]
     steps:
       - name: checkout


### PR DESCRIPTION
Fix this point in #290:
- Fix the latest tag issue, this tag should not be used
