### PR TITLE
Fix host not found error of data-analytics.

### DIFF
--- a/commons/hadoop/2.10.1/files/entrypoint.sh
+++ b/commons/hadoop/2.10.1/files/entrypoint.sh
@@ -19,7 +19,7 @@ case $1 in
     sed -i "s/master/$HOSTNAME/g" $HADOOP_PREFIX/etc/hadoop/core-site.xml
     sed -i "s/master/$HOSTNAME/g" $HADOOP_PREFIX/etc/hadoop/yarn-site.xml
     # update /etc/hosts with IP (only needed when using host networking)
-    if [ -n $2 ]; then
+    if [[ $2 ]]; then
       cp /etc/hosts /tmp/hosts
       sed -i "s/127.0.1.1/$2/g" /tmp/hosts
       cp /tmp/hosts /etc/hosts
@@ -38,7 +38,7 @@ case $1 in
     sed -i "s/master/$HOSTNAME/g" $HADOOP_PREFIX/etc/hadoop/core-site.xml
     sed -i "s/master/$HOSTNAME/g" $HADOOP_PREFIX/etc/hadoop/yarn-site.xml
     # update /etc/hosts with IP (only needed when using host networking)
-    if [ -n $3 ]; then
+    if [[ $3 ]]; then
       cp /etc/hosts /tmp/hosts
       sed -i "s/127.0.1.1/$3/g" /tmp/hosts
       cp /tmp/hosts /etc/hosts

--- a/docs/benchmarks/data-analytics.md
+++ b/docs/benchmarks/data-analytics.md
@@ -12,7 +12,7 @@ The benchmark consists of running a Naive Bayes classifier on a Wikimedia datase
 To obtain the images:
 
 ```bash
-$ docker pull cloudsuite/hadoop:2.9.2
+$ docker pull cloudsuite/hadoop:2.10.1
 $ docker pull cloudsuite/data-analytics:4.0
 
 ```
@@ -37,7 +37,7 @@ $ docker run -d --net host --name slave02 cloudsuite/hadoop:2.9.2 slave $IP_ADRE
 
 ...
 ```
-Note : Start each slave on a different VM.
+Note : Start each slave on a different VM. If they are running on the same host rather than multiple VMs, you should set `IP_ADRESS_MASTER` to `127.0.1.1`.
 
 Run the benchmark with:
 

--- a/docs/commons/hadoop.md
+++ b/docs/commons/hadoop.md
@@ -1,20 +1,20 @@
 ## Hadoop
-Currently supported version is 2.9.2.
+Currently supported version is 2.10.1.
 
 To obtain / build the image :
 ```
-$ docker pull cloudsuite/hadoop:2.9.2
+$ docker pull cloudsuite/hadoop:2.10.1
 
 or
 
-$ cd /path/to/cloudsuite/commons/hadoop/2.9.2
-$ docker build --network host -t cloudsuite/hadoop:2.9.2 .
+$ cd /path/to/cloudsuite/commons/hadoop/2.10.1
+$ docker build --network host -t cloudsuite/hadoop:2.10.1 .
 ```
 
 ### Running Hadoop
 Start Hadoop master with:
 ```
-$ docker run -d --net host --name master cloudsuite/hadoop:2.9.2 master
+$ docker run -d --net host --name master cloudsuite/hadoop:2.10.1 master
 ```
 
 Start any number of Hadoop slaves with:
@@ -27,7 +27,7 @@ $ docker run -d --net host --name slave02 cloudsuite/hadoop:2.9.2 slave $IP_ADRE
 
 ...
 ```
-Note : Start each slave on a different VM.
+Note : Start each slave on a different VM. If they are running on the same host rather than multiple VMs, you should set `IP_ADRESS_MASTER` to `127.0.1.1`.
 
 Run the supplied example job (grep) with:
 ```


### PR DESCRIPTION
Address #308.
The reason why master cannot resolve the hostname is that we use the wrong comparison operator in bash:
```sh
if [ -n $2 ]; then
```
In this case, even if $2 is defined as an empty value, the condition hold. And, this will remove the hostname from hosts.
I also found address `127.0.1.1` instead of `127.0.0.1` should be used to test the image locally. They have slight differences in my machine. 127.0.0.1 is defined as localhost, and 127.0.1.1 is defined as _hostname_.localdomain.
