### PR TITLE
Keep libevent on the image

### DIFF
--- a/benchmarks/data-caching/client/Dockerfile
+++ b/benchmarks/data-caching/client/Dockerfile
@@ -6,10 +6,6 @@ RUN groupadd -r memcache && useradd -r -g memcache memcache
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# libevent-dev will include libevent, so it's not necessary to install it standalone
-# RUN apt-get update && apt-get install -y libevent-2.1-6 vim --no-install-recommends \
-	# && rm -rf /var/lib/apt/lists/*
-
 RUN buildDeps='curl gcc libc6-dev make' \	
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps libevent-dev vim --no-install-recommends \

--- a/benchmarks/data-caching/client/Dockerfile
+++ b/benchmarks/data-caching/client/Dockerfile
@@ -10,9 +10,9 @@ ENV DEBIAN_FRONTEND noninteractive
 # RUN apt-get update && apt-get install -y libevent-2.1-6 vim --no-install-recommends \
 	# && rm -rf /var/lib/apt/lists/*
 
-RUN buildDeps='curl gcc libc6-dev libevent-dev make' \	
+RUN buildDeps='curl gcc libc6-dev make' \	
 	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps vim --no-install-recommends \
+	&& apt-get update && apt-get install -y $buildDeps libevent-dev vim --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& curl -k -L --remote-name http://github.com/parsa-epfl/memcached-loadtester/archive/refs/tags/v4.0.tar.gz \
 	&& mkdir -p /usr/src/memcached \


### PR DESCRIPTION
When I tried to run the benchmark, I found that libevent is required to run the `./loader` command. However, it was purged in the Dockerfile. This PR keeps the package to let the image work properly. 