### PR TITLE
Fix web serving run error.

### DIFF
--- a/benchmarks/web-serving/db_server/Dockerfile
+++ b/benchmarks/web-serving/db_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudsuitetest/mysql:mariadb-10.3
+FROM cloudsuite/mysql:mariadb-10.3
 LABEL maintainer="Mark Sutherland <mark.sutherland@epfl.ch>"
 
 ENV root_password root

--- a/benchmarks/web-serving/faban_client/Dockerfile
+++ b/benchmarks/web-serving/faban_client/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudsuitetest/faban:1.4
+FROM cloudsuite/faban:1.4
 LABEL maintainer="Mark Sutherland <mark.sutherland@epfl.ch>"
 
 RUN apt-get update && apt-get install -y \

--- a/benchmarks/web-serving/memcached_server/Dockerfile
+++ b/benchmarks/web-serving/memcached_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudsuitetest/memcached:1.6.6
+FROM cloudsuite/memcached:1.6.6
 LABEL maintainer="Mark Sutherland <mark.sutherland@epfl.ch>"
 
 # the entry point is already memcached

--- a/commons/mysql/mariadb-10.3/Dockerfile
+++ b/commons/mysql/mariadb-10.3/Dockerfile
@@ -1,15 +1,15 @@
-FROM cloudsuitetest/debian:base-os
+FROM cloudsuite/debian:base-os
 
 LABEL maintainer="Mark Sutherland <mark.sutherland@epfl.ch>"
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV root_password root
 
-RUN echo mysql-server mysql-server/root_password password ${root_password} |  /usr/bin/debconf-set-selections	
-RUN echo mysql-server mysql-server/root_password_again password ${root_password} |  /usr/bin/debconf-set-selections
-	
-RUN apt-get update \
-    && apt-get install -y default-mysql-server
+RUN echo mariadb-server-10.3 mysql-server/root_password password ${root_password} |  /usr/bin/debconf-set-selections
+RUN echo mariadb-server-10.3 mysql-server/root_password_again password ${root_password} |  /usr/bin/debconf-set-selections
+
+RUN apt update -q \
+    && apt install -y default-mysql-server
 
 # Allow it to listen from outer world	
 RUN echo "[mysqld]" >> /etc/mysql/my.cnf

--- a/docs/benchmarks/web-serving.md
+++ b/docs/benchmarks/web-serving.md
@@ -21,6 +21,9 @@ Supported tags and their respective `Dockerfile` links:
 
 These images are automatically built using the mentioned Dockerfiles available on the `parsa-epfl/cloudsuite` [GitHub repo][repo].
 
+### IP Addresses ###
+Assign explicit IP address of the host running a particular server throughout this documentation. 
+
 ### Starting the database server ####
 To start the database server, you have to first `pull` the server image. To `pull` the server image use the following command:
 
@@ -55,7 +58,7 @@ To run the web server *with HHVM enabled*, use the following command:
 
     $ docker run -e "HHVM=true" -dt --net=host --name=web_server_local cloudsuite/web-serving:web_server /etc/bootstrap.sh ${DATABASE_SERVER_IP} ${MEMCACHED_SERVER_IP} ${MAX_PM_CHILDREN}
 
-The three ${DATABASE_SERVER_IP},${MEMCACHED_SERVER_IP}, and ${MAX_PM_CHILDREN} parameters are optional. The ${DATABASE_SERVER_IP}, and ${MEMCACHED_SERVER_IP} show the IP (or the container name) of the database server, and the IP (or the container name) of the memcached server, respectively. For example, if you are running all the containers on the same machine and use the host network you can use the localhost IP (127.0.0.1). Their default values are database_server, and memcache_server, respectively, which are the default names of the containers. 
+The three ${DATABASE_SERVER_IP},${MEMCACHED_SERVER_IP}, and ${MAX_PM_CHILDREN} parameters are optional. The ${DATABASE_SERVER_IP}, and ${MEMCACHED_SERVER_IP} show the IP (or the container name) of the database server, and the IP (or the container name) of the memcached server, respectively. Their default values are database_server, and memcache_server, respectively, which are the default names of the containers. 
 The ${MAX_PM_CHILDREN} set the pm.max_children in the php-fpm setting. The default value is 80. 
 
 ###  Running the benchmark ###

--- a/docs/benchmarks/web-serving.md
+++ b/docs/benchmarks/web-serving.md
@@ -22,7 +22,7 @@ Supported tags and their respective `Dockerfile` links:
 These images are automatically built using the mentioned Dockerfiles available on the `parsa-epfl/cloudsuite` [GitHub repo][repo].
 
 ### IP Addresses ###
-Assign explicit IP address of the host running a particular server throughout this documentation. 
+Please note that all IP addresses should refer to the explicit IP address of the host server running each container.
 
 ### Starting the database server ####
 To start the database server, you have to first `pull` the server image. To `pull` the server image use the following command:
@@ -58,8 +58,7 @@ To run the web server *with HHVM enabled*, use the following command:
 
     $ docker run -e "HHVM=true" -dt --net=host --name=web_server_local cloudsuite/web-serving:web_server /etc/bootstrap.sh ${DATABASE_SERVER_IP} ${MEMCACHED_SERVER_IP} ${MAX_PM_CHILDREN}
 
-The three ${DATABASE_SERVER_IP},${MEMCACHED_SERVER_IP}, and ${MAX_PM_CHILDREN} parameters are optional. The ${DATABASE_SERVER_IP}, and ${MEMCACHED_SERVER_IP} show the IP (or the container name) of the database server, and the IP (or the container name) of the memcached server, respectively. Their default values are database_server, and memcache_server, respectively, which are the default names of the containers. 
-The ${MAX_PM_CHILDREN} set the pm.max_children in the php-fpm setting. The default value is 80. 
+The three ${DATABASE_SERVER_IP},${MEMCACHED_SERVER_IP}, and ${MAX_PM_CHILDREN} parameters are optional. The ${DATABASE_SERVER_IP}, and ${MEMCACHED_SERVER_IP} show the IP of the database server, and the IP of the memcached server, respectively. The ${MAX_PM_CHILDREN} set the pm.max_children in the php-fpm setting. The default value is 80. 
 
 ###  Running the benchmark ###
 


### PR DESCRIPTION
Fix the debconf file creation so that mariadb installs itself with the correct password when the image is built.

This closes issue #322 .