### PR TITLE
Add Master's hostname must be resolvable in doc.

### DIFF
--- a/docs/benchmarks/data-analytics.md
+++ b/docs/benchmarks/data-analytics.md
@@ -14,12 +14,13 @@ To obtain the images:
 ```bash
 $ docker pull cloudsuite/hadoop:2.10.1
 $ docker pull cloudsuite/data-analytics:4.0
-
 ```
 
 ## Running the benchmark ##
 
 The benchmark is designed to run on a Hadoop cluster, where the single master runs the driver program, and the slaves run the mappers and reducers.
+
+**Note**: The following commands will run the Hadoop cluster within host's network. To make sure that slaves and master can communicate with each other, the master container's hostname, which should be host's hostname, must be able to be resolved to the same IP address by the master container and all slave containers. 
 
 Start the master with:
 
@@ -37,7 +38,7 @@ $ docker run -d --net host --name slave02 cloudsuite/hadoop:2.10.1 slave $IP_ADD
 
 ...
 ```
-Note : Start each slave on a different VM. If they are running on the same host rather than multiple VMs, you should set `IP_ADDRESS_MASTER` to `127.0.1.1`.
+**Note**: You should set `IP_ADDRESS_MASTER` to master's IP address.
 
 Run the benchmark with:
 

--- a/docs/benchmarks/data-serving.md
+++ b/docs/benchmarks/data-serving.md
@@ -11,15 +11,11 @@ The YCSB client has a data generator. After starting Cassandra, YCSB can start l
 
 
 ### Server Container
+
+**Note**: The following commands will run the Cassandra within host's network. To make sure that slaves and master can communicate with each other, the master container's hostname, which should be host's hostname, must be able to be resolved to the same IP address by the master container and all slave containers. 
+
 Start the server container that will run cassandra server and installs a default keyspace usertable:
 
----
-**NOTE**
-
-Make sure the hostname of the machines where the server docker container are deployed must be reachable/pingable. 
-If the hostname is not pingable on the machine, add an entry in /etc/hosts file.
-
----
 ```bash
 $ docker run --name cassandra-server --privileged --net host cloudsuite/data-serving:server
 ```

--- a/docs/benchmarks/graph-analytics.md
+++ b/docs/benchmarks/graph-analytics.md
@@ -39,6 +39,8 @@ workers (each running in a Docker container) that can be spread across
 multiple nodes in a cluster. For more information on running Spark
 with Docker look at [cloudsuite/spark:2.4.5][spark-dhrepo].
 
+**Note**: The following commands will run the Spark cluster within host's network. To make sure that slaves and master can communicate with each other, the master container's hostname, which should be host's hostname, must be able to be resolved to the same IP address by the master container and all slave containers. 
+
 First, create a dataset image on every physical node where Spark
 workers will be running.
 

--- a/docs/benchmarks/in-memory-analytics.md
+++ b/docs/benchmarks/in-memory-analytics.md
@@ -69,6 +69,8 @@ This section explains how to run the benchmark using multiple Spark workers
 in a cluster. For more information on running Spark with Docker look at
 [cloudsuite/spark:2.4.5][spark-dhrepo].
 
+**Note**: The following commands will run the Spark cluster within host's network. To make sure that slaves and master can communicate with each other, the master container's hostname, which should be host's hostname, must be able to be resolved to the same IP address by the master container and all slave containers. 
+
 First, create a dataset image on every physical node where Spark workers will
 be running.
 

--- a/docs/commons/hadoop.md
+++ b/docs/commons/hadoop.md
@@ -12,6 +12,9 @@ $ docker build --network host -t cloudsuite/hadoop:2.10.1 .
 ```
 
 ### Running Hadoop
+
+**Note**: The following commands will run the Hadoop cluster within host's network. To make sure that slaves and master can communicate with each other, the master container's hostname, which should be host's hostname, must be able to be resolved to the same IP address by the master container and all slave containers. 
+
 Start Hadoop master with:
 ```
 $ docker run -d --net host --name master cloudsuite/hadoop:2.10.1 master
@@ -20,14 +23,14 @@ $ docker run -d --net host --name master cloudsuite/hadoop:2.10.1 master
 Start any number of Hadoop slaves with:
 ```
 $ # on VM1
-$ docker run -d --net host --name slave01 cloudsuite/hadoop:2.10.1 slave $IP_ADDRESS_MASTER
+$ docker run -d --net host --name slave01 cloudsuite/hadoop:2.10.1 slave $MASTER_ADDRESS
 
 $ # on VM2
-$ docker run -d --net host --name slave02 cloudsuite/hadoop:2.10.1 slave $IP_ADDRESS_MASTER
+$ docker run -d --net host --name slave02 cloudsuite/hadoop:2.10.1 slave $MASTER_ADDRESS
 
 ...
 ```
-Note : Start each slave on a different VM. If they are running on the same host rather than multiple VMs, you should set `IP_ADDRESS_MASTER` to `127.0.1.1`.
+**Note**: You should set `MASTER_ADDRESS` to master's IP address.
 
 Run the supplied example job (grep) with:
 ```

--- a/docs/commons/spark.md
+++ b/docs/commons/spark.md
@@ -45,10 +45,10 @@ Again, this is just a shortcut for starting a container and running
 
 ### Multi Container
 
-Usually, we want to run Spark with multiple workers to parallelize some job. In
-Docker it is typical to run a single process in a single container. Here we
-show how to start a number of workers, a single Spark master that acts as a
-coordinator (cluster manager), and submit a job.
+Usually, we want to run Spark with multiple workers to parallelize some job. In Docker it is typical to run a single process in a single container. Here we show how to start a number of workers, a single Spark master that acts as a coordinator (cluster manager), and submit a job.
+
+**Note**: The following commands will run the Spark cluster within host's network. To make sure that slaves and master can communicate with each other, the master container's hostname, which should be host's hostname, must be able to be resolved to the same IP address by the master container and all slave containers. 
+
 
 Start a Spark master:
 


### PR DESCRIPTION
Hadoop, Spark, and Cassandra use FQDN to communicate with each other. In the document, we should mention that this address must be resolvable before running both master and slave containers.
I don't mention the way to do this, like "adding an entry in the /etc/hosts file". @Hnefi 's idea is to let the user determine how to do it.
This PR addresses #308. 