### PR TITLE
No push of separated multi-arch images

### DIFF
--- a/.github/scripts/build-images.sh
+++ b/.github/scripts/build-images.sh
@@ -59,9 +59,9 @@ if (grep -q "${DF_PATH#./}" <<<$modified_files) || # Rebuild the image if any fi
         cd $DF_PATH
         for arch in amd64 arm64 riscv64; do 
             if [ $IMG_TAG = "openjdk11" ]; then
-                docker buildx build --platform=linux/${arch} -t $DH_REPO:${arch} -f Dockerfile --build-arg EXTERNAL_ARG="/usr/lib/jvm/java-11-openjdk-${arch}/" $DO_PUSH .
+                docker buildx build --platform=linux/${arch} -t $DH_REPO:${arch} -f Dockerfile --build-arg EXTERNAL_ARG="/usr/lib/jvm/java-11-openjdk-${arch}/" --load .
             else
-                docker buildx build --platform=linux/${arch} -t $DH_REPO:${arch} -f Dockerfile.${arch} $DO_PUSH . 
+                docker buildx build --platform=linux/${arch} -t $DH_REPO:${arch} -f Dockerfile.${arch} --load . 
             fi
 
             if [ $? != "0" ]; then

--- a/commons/base-os/build.sh
+++ b/commons/base-os/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 for arch in amd64 arm64 riscv64; do
-    docker buildx build --platform=linux/${arch} -t cloudsuite/base-os:${arch} -f Dockerfile.${arch} --push .
+    docker buildx build --platform=linux/${arch} -t cloudsuite/base-os:${arch} -f Dockerfile.${arch} --load .
 done
 
 docker manifest create --amend cloudsuite/base-os:debian cloudsuite/base-os:amd64 cloudsuite/base-os:arm64 cloudsuite/base-os:riscv64


### PR DESCRIPTION
This PR stops uploading separated multi-arch images when images are built by Github Action.
The build script for base-os is also updated. 