### PR TITLE
Revert "Fix the wrong order of manifest list creation (#338)"

### DIFF
--- a/.github/scripts/build-images.sh
+++ b/.github/scripts/build-images.sh
@@ -59,22 +59,19 @@ if (grep -q "${DF_PATH#./}" <<<$modified_files) || # Rebuild the image if any fi
         cd $DF_PATH
         for arch in amd64 arm64 riscv64; do 
             if [ $IMG_TAG = "openjdk11" ]; then
-                docker buildx build --platform=linux/${arch} -t $DH_REPO:${arch} -f Dockerfile --build-arg EXTERNAL_ARG="/usr/lib/jvm/java-11-openjdk-${arch}/" --load .
+                docker buildx build --platform=linux/${arch} -t $DH_REPO:${arch} -f Dockerfile --build-arg EXTERNAL_ARG="/usr/lib/jvm/java-11-openjdk-${arch}/" $DO_PUSH .
             else
-                docker buildx build --platform=linux/${arch} -t $DH_REPO:${arch} -f Dockerfile.${arch} --load . 
+                docker buildx build --platform=linux/${arch} -t $DH_REPO:${arch} -f Dockerfile.${arch} $DO_PUSH . 
             fi
 
             if [ $? != "0" ]; then
                 exit 1
             fi
-        done
-        if [ -n "$DO_PUSH" ]; then
-            docker manifest create --amend $DH_REPO:$IMG_TAG $DH_REPO:amd64 $DH_REPO:arm64 $DH_REPO:riscv64
-            docker manifest push $DH_REPO:$IMG_TAG
-            if [ $? != "0" ]; then
-                exit 1
+            if [ -n "$DO_PUSH" ]; then
+                docker manifest create --amend $DH_REPO:$IMG_TAG $DH_REPO:amd64 $DH_REPO:arm64 $DH_REPO:riscv64
+                docker manifest push $DH_REPO:$IMG_TAG
             fi
-        fi
+        done
     else
         docker buildx build --platform $DBX_PLATFORM -t $DH_REPO:$IMG_TAG $DO_PUSH $DF_PATH
     fi

--- a/commons/base-os/build.sh
+++ b/commons/base-os/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 for arch in amd64 arm64 riscv64; do
-    docker buildx build --platform=linux/${arch} -t cloudsuite/base-os:${arch} -f Dockerfile.${arch} --load .
+    docker buildx build --platform=linux/${arch} -t cloudsuite/base-os:${arch} -f Dockerfile.${arch} --push .
 done
 
 docker manifest create --amend cloudsuite/base-os:debian cloudsuite/base-os:amd64 cloudsuite/base-os:arm64 cloudsuite/base-os:riscv64


### PR DESCRIPTION
This PR reverts Previous PR #338 where I try to avoid the uploading of multi-arch images. This is finally proofed to be infeasible, because creating a manifest list will retrieve the tag name from the Dockerhub. 