### PR TITLE
Enable arm64 hhvm

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         tag: ["3.30"]
-        platform: ["linux/amd64"]
+        platform: ["linux/amd64,linux/arm64"]
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The purpose of this PR is to test if we could build HHVM for arm64. 