### PR TITLE
debugging media streaming

### DIFF
--- a/benchmarks/media-streaming/client/files/videoperf/gen/videosesslog.c
+++ b/benchmarks/media-streaming/client/files/videoperf/gen/videosesslog.c
@@ -614,7 +614,7 @@ parse_config (void)
  	int log_file_counter = 0;
 
 	// Initialize the session_templates, depending on the number of log files specified
- 	session_logs = malloc(param.videosesslog.num_logs * sizeof(Session_Log_Desc));	
+ 	session_logs = calloc(param.videosesslog.num_logs * sizeof(Session_Log_Desc), 1);	
 
 	// Build the request-mix cdf
 	build_request_mix_cdf();

--- a/benchmarks/media-streaming/client/files/videoperf/stat/basic.c
+++ b/benchmarks/media-streaming/client/files/videoperf/stat/basic.c
@@ -537,8 +537,8 @@ conn_destroyed (Event_Type et, Object *obj, Any_Type reg_arg, Any_Type c_arg)
 		++basic.num_lifetimes;
 		bin = lifetime*NUM_BINS/MAX_LIFETIME;
 		if (bin >= NUM_BINS)
-			bin = NUM_BINS;
-		++basic.conn_lifetime_hist[bin-1];
+			bin = NUM_BINS-1;
+		++basic.conn_lifetime_hist[bin];
 	}
 #endif /* UW_STABLE_STATS */
 


### PR DESCRIPTION
This PR fixes two bugs that I found in the media streaming benchmark. 
1. ASAN detects a bug at [this line](https://github.com/parsa-epfl/cloudsuite/blob/main/benchmarks/media-streaming/client/files/videoperf/gen/videosesslog.c#L732). The reason is that when the benchmark starts execution, sptr is not NULL as expected at [this line](https://github.com/parsa-epfl/cloudsuite/blob/main/benchmarks/media-streaming/client/files/videoperf/gen/videosesslog.c#L715), and sptr is initialized at [this line](https://github.com/parsa-epfl/cloudsuite/blob/main/benchmarks/media-streaming/client/files/videoperf/gen/videosesslog.c#L634) which indicates that current_session_log should be correctly initialized at [this line](https://github.com/parsa-epfl/cloudsuite/blob/main/benchmarks/media-streaming/client/files/videoperf/gen/videosesslog.c#L622). As it needs a proper initialization of session_logs at [this line](https://github.com/parsa-epfl/cloudsuite/blob/main/benchmarks/media-streaming/client/files/videoperf/gen/videosesslog.c#L617), we conclude that instead of malloc, we should allocate the memory using calloc to set all bytes to 0/null.  
2. After fixing this bug, another bug also exists that causes thread crashes. It is at [this line](https://github.com/parsa-epfl/cloudsuite/blob/main/benchmarks/media-streaming/client/files/videoperf/stat/basic.c#L541), and when the bin is 0, the code tries to access index -1 of the histogram array which causes index out of bound error. To fix this bug, I changed the code to update the histogram like the implementation written on lines 516 to 518 of the same file. 

