### PR TITLE
modify memcached to be built on riscv

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -103,7 +103,7 @@ jobs:
       is_parent_modified: ${{ steps.set_is_parent_modified.outputs.is_parent_modified }}
     strategy:
       matrix:
-        tag: ["1.6.10"]
+        tag: ["1.6.15"]
         platform: ["linux/amd64,linux/arm64,linux/riscv64"]
     steps:
       - name: checkout

--- a/benchmarks/data-caching/server/Dockerfile
+++ b/benchmarks/data-caching/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudsuite/memcached:1.6.10
+FROM cloudsuite/memcached:1.6.15
 
 # the entry point is set to memcached in the base image
 CMD ["-t", "2", "-m", "2048", "-n", "550"]

--- a/benchmarks/django-workload/memcached/Dockerfile
+++ b/benchmarks/django-workload/memcached/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudsuite/memcached:1.6.10
+FROM cloudsuite/memcached:1.6.15
 
 COPY files/* /scripts/
 USER root

--- a/benchmarks/web-serving/memcached_server/Dockerfile
+++ b/benchmarks/web-serving/memcached_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudsuite/memcached:1.6.10
+FROM cloudsuite/memcached:1.6.15
 
 # the entry point is already memcached
 CMD ["-m", "65535", "-t", "4"]

--- a/commons/memcached/1.6.10/Dockerfile
+++ b/commons/memcached/1.6.10/Dockerfile
@@ -12,25 +12,29 @@ RUN set -eux; \
     case "${ARCH}" in \
        aarch64|arm64|amd64|x86_64) \
          LIBEVENT_VER='2.1-6'; \
+         GCC='gcc'; \
+         apt-get update && apt-get install -y --no-install-recommends libevent-${LIBEVENT_VER} ${GCC}; \
         ;; \
        riscv64) \
          LIBEVENT_VER='2.1-7'; \
+         GCC='gcc-11'; \
+         apt-get update && apt-get install -y --no-install-recommends libevent-${LIBEVENT_VER} ${GCC}; \
+         ln -s /usr/bin/${GCC} /usr/bin/gcc; \
         ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \
          exit 1; \
          ;; \
-    esac; \
-    apt-get update && apt-get install -y --no-install-recommends libevent-${LIBEVENT_VER} && rm -rf /var/lib/apt/lists/*;
+    esac; 
 
 ENV MEMCACHED_VERSION 1.6.10
 
 # this checksum was not provided with the author of memcached, it is checksum of the working downloaded version
 ENV MEMCACHED_SHA1 cb5b9fe77a2a59cc6cc7103a415bc07df9ddc6ec 
 
-RUN buildDeps='curl gcc libc6-dev libevent-dev make perl' \
+RUN buildDeps='curl libc6-dev libevent-dev make perl' \
 	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+	&& apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "http://memcached.org/files/memcached-$MEMCACHED_VERSION.tar.gz" -o memcached.tar.gz \
 	&& echo "$MEMCACHED_SHA1 memcached.tar.gz" | sha1sum -c - \

--- a/commons/memcached/1.6.15/Dockerfile
+++ b/commons/memcached/1.6.15/Dockerfile
@@ -12,27 +12,23 @@ RUN set -eux; \
     case "${ARCH}" in \
        aarch64|arm64|amd64|x86_64) \
          LIBEVENT_VER='2.1-6'; \
-         GCC='gcc'; \
-         apt-get update && apt-get install -y --no-install-recommends libevent-${LIBEVENT_VER} ${GCC}; \
         ;; \
        riscv64) \
          LIBEVENT_VER='2.1-7'; \
-         GCC='gcc-11'; \
-         apt-get update && apt-get install -y --no-install-recommends libevent-${LIBEVENT_VER} ${GCC}; \
-         ln -s /usr/bin/${GCC} /usr/bin/gcc; \
         ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \
          exit 1; \
          ;; \
-    esac; 
+    esac; \
+    apt-get update && apt-get install -y --no-install-recommends libevent-${LIBEVENT_VER}
 
-ENV MEMCACHED_VERSION 1.6.10
+ENV MEMCACHED_VERSION 1.6.15
 
 # this checksum was not provided with the author of memcached, it is checksum of the working downloaded version
-ENV MEMCACHED_SHA1 cb5b9fe77a2a59cc6cc7103a415bc07df9ddc6ec 
+ENV MEMCACHED_SHA1 badcfa0d65f5797cc9c2f957f3fbfedbd8c13411
 
-RUN buildDeps='curl libc6-dev libevent-dev make perl' \
+RUN buildDeps='curl gcc libc6-dev libevent-dev make perl' \
 	&& set -x \
 	&& apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
This PR addresses issue #365. The risc-v container installs gcc-12 that cannot compile Memcached. This PR simply installs gcc-11 for the riscv container that successfully compiles and installs Memcached.  