### PR TITLE
Remove Unnecessary Space In Bash Script

### DIFF
--- a/benchmarks/web-serving/faban_client/files/web20_benchmark/run/entrypoint.sh
+++ b/benchmarks/web-serving/faban_client/files/web20_benchmark/run/entrypoint.sh
@@ -23,7 +23,7 @@ while (( ${#@} )); do
     --max=*)        TMAX=${1#*=} ;;
     --type=*)       TYPE=${1#*=} ;;
     --dist=*)       DIST=${1#*=} ;;
-    --encryption=*) TLS= ${1#*=} ;;
+    --encryption=*) TLS=${1#*=}  ;;
     *)              ARGS+=(${1}) ;;
   esac
 

--- a/benchmarks/web-serving/faban_client/files/web20_benchmark/run/entrypoint.sh
+++ b/benchmarks/web-serving/faban_client/files/web20_benchmark/run/entrypoint.sh
@@ -183,7 +183,6 @@ then
   run
   fini
 else
-then
     echo "Operation ${OPER} is not valid"
     exit 0
 fi


### PR DESCRIPTION
This PR fixes the problem when parsing the argument `encryption`. Since we add a space, it will treat the value as a command, thus letting the program ignore the value from outside.