### PR TITLE
Force Choosing First Local IP For Cassandra

### DIFF
--- a/benchmarks/data-serving/server/files/docker-entrypoint.sh
+++ b/benchmarks/data-serving/server/files/docker-entrypoint.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 set -e
 
-echo Server IP
-hostname --ip-address
+# It's possible that one machine has multiple ip addresses mapped to the hostname
+# For instance, ARM image inside QEMU has this problem.
+# Therefore, we will only keep the first IP address where the Cassandra server is also listened.
+
+LISTEN_IP=$(cut --delimiter=" " -f1 <<< $(hostname --ip-address))
+
+echo Server will listen on IP: $LISTEN_IP
 
 if [ -z "$CASSANDRA_SEEDS" ]; then
     NEED_INIT=1
@@ -22,13 +27,13 @@ if [ "$1" = 'cassandra' ] || [ "$1" = 'bash' ]; then
 
 	: ${CASSANDRA_LISTEN_ADDRESS='auto'}
 	if [ "$CASSANDRA_LISTEN_ADDRESS" = 'auto' ]; then
-		CASSANDRA_LISTEN_ADDRESS="$(hostname --ip-address)"
+		CASSANDRA_LISTEN_ADDRESS="$LISTEN_IP"
 	fi
 
 	: ${CASSANDRA_BROADCAST_ADDRESS="$CASSANDRA_LISTEN_ADDRESS"}
 
 	if [ "$CASSANDRA_BROADCAST_ADDRESS" = 'auto' ]; then
-		CASSANDRA_BROADCAST_ADDRESS="$(hostname --ip-address)"
+		CASSANDRA_BROADCAST_ADDRESS="$LISTEN_IP"
 	fi
 	: ${CASSANDRA_BROADCAST_RPC_ADDRESS:=$CASSANDRA_BROADCAST_ADDRESS}
 


### PR DESCRIPTION
This PR forces to pick the first local IP address when multiple addresses is available. In this case, It won't pass wrong arguments to Cassandra's config file, which at present causes the error of starting up on ARM/RISC-V QEMU. 