### PR TITLE
set cipher to TLS_AES_128_GCM_SHA256

### DIFF
--- a/benchmarks/media-streaming/client/files/run/peak_hunter/launch_remote.sh
+++ b/benchmarks/media-streaming/client/files/run/peak_hunter/launch_remote.sh
@@ -16,7 +16,7 @@ fi
 if [ $mode = "PT" ];then
   mode="--port 80"
 elif [ $mode = "TLS" ]; then
-  mode="--ssl --port 443"
+  mode="--ssl --port 443 --ssl-ciphers TLS_AES_128_GCM_SHA256"
 else 
   echo "invalid encryption mode flag"
   exit

--- a/benchmarks/media-streaming/client/files/videoperf/conn.c
+++ b/benchmarks/media-streaming/client/files/videoperf/conn.c
@@ -88,7 +88,7 @@ conn_init (Conn *conn)
       if (param.ssl_cipher_list)
 	{
 	  /* set order of ciphers  */
-	  int ssl_err = SSL_set_cipher_list (conn->ssl, param.ssl_cipher_list);
+	  int ssl_err = SSL_set_ciphersuites (conn->ssl, param.ssl_cipher_list);
 
 	  if (DBG > 2)
 	    fprintf (stderr, "core_ssl_connect: set_cipher_list returned %d\n",

--- a/benchmarks/media-streaming/server/files/nginx.location.append
+++ b/benchmarks/media-streaming/server/files/nginx.location.append
@@ -104,14 +104,15 @@ server {
 #	root html;
 #	index index.html index.htm;
 #
-	ssl on;
+
+#	ssl on;
 	ssl_certificate media_streaming_CS_4.crt;
 	ssl_certificate_key media_streaming_CS_4.key;
 #
 #	ssl_session_timeout 5m;
 #
 	ssl_protocols TLSv1.3;
-	ssl_ciphers "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";
+	ssl_ciphers 'TLS13+AESGCM+AES128:EECDH+AES128';
 	ssl_prefer_server_ciphers on;
 #
 #	location / {


### PR DESCRIPTION
This PR sets the cipher chosen by the videoperf to `TLS_AES_128_GCM_SHA256`. It is the cipher used by both NetFlix and YouTube. 