### PR TITLE
Escape dolar signs in web-serving documentation

### DIFF
--- a/docs/benchmarks/web-serving.md
+++ b/docs/benchmarks/web-serving.md
@@ -54,8 +54,8 @@ To run the web server *with HHVM enabled*, use the following command:
 
     $ docker run -e "HHVM=true" -dt --net=host --name=web_server_local cloudsuite3/web-serving:web_server /etc/bootstrap.sh ${DATABASE_SERVER_IP} ${MEMCACHED_SERVER_IP} ${MAX_PM_CHILDREN}
 
-The three \${DATABASE_SERVER_IP},\${MEMCACHED_SERVER_IP}, and \${MAX_PM_CHILDREN} parameters are optional. The ${DATABASE_SERVER_IP}, and ${MEMCACHED_SERVER_IP} show the IP (or the container name) of the database server, and the IP (or the container name) of the memcached server, respectively. For example, if you are running all the containers on the same machine and use the host network you can use the localhost IP (127.0.0.1). Their default values are mysql_server, and memcache_server, respectively, which are the default names of the containers. 
-The ${MAX_PM_CHILDREN} set the pm.max_children in the php-fpm setting. The default value is 80. 
+The three \${DATABASE_SERVER_IP},\${MEMCACHED_SERVER_IP}, and \${MAX_PM_CHILDREN} parameters are optional. The \${DATABASE_SERVER_IP}, and \${MEMCACHED_SERVER_IP} show the IP (or the container name) of the database server, and the IP (or the container name) of the memcached server, respectively. For example, if you are running all the containers on the same machine and use the host network you can use the localhost IP (127.0.0.1). Their default values are mysql_server, and memcache_server, respectively, which are the default names of the containers. 
+The \${MAX_PM_CHILDREN} set the pm.max_children in the php-fpm setting. The default value is 80. 
 
 ###  Running the benchmark ###
 


### PR DESCRIPTION
There were some unescaped dolar signs in the web serving documentation that were messing with markdown formatting.