### PR TITLE
changed hadoop master listening address to 0.0.0.0

### DIFF
--- a/commons/hadoop/2.10.1/files/entrypoint.sh
+++ b/commons/hadoop/2.10.1/files/entrypoint.sh
@@ -21,7 +21,7 @@ case $1 in
     # update /etc/hosts with IP (only needed when using host networking)
     if [[ $2 ]]; then
       cp /etc/hosts /tmp/hosts
-      sed -i "s/127.0.1.1/$2/g" /tmp/hosts
+      sed -i "s/0.0.0.0/$2/g" /tmp/hosts
       cp /tmp/hosts /etc/hosts
     fi
     # start Hadoop daemons
@@ -40,7 +40,7 @@ case $1 in
     # update /etc/hosts with IP (only needed when using host networking)
     if [[ $3 ]]; then
       cp /etc/hosts /tmp/hosts
-      sed -i "s/127.0.1.1/$3/g" /tmp/hosts
+      sed -i "s/0.0.0.0/$3/g" /tmp/hosts
       cp /tmp/hosts /etc/hosts
     fi
     # start Hadoop daemons


### PR DESCRIPTION
In file `cloudsuite/commons/hadoop/2.10.1/files/entrypoint.sh`,  I have changed the listening address to `0.0.0.0` from `127.0.1.1`. I am confused about how to expose the ports so, any insight into that will be very helpful for me.