### PR TITLE
Add Latency to Wait for Killing Old Solr

### DIFF
--- a/benchmarks/web-search/server/docker-entrypoint.sh
+++ b/benchmarks/web-search/server/docker-entrypoint.sh
@@ -11,7 +11,12 @@ $SOLR_HOME/bin/solr start -force -cloud -p $SOLR_PORT -s $SOLR_CORE_DIR -m $SERV
 $SOLR_HOME/bin/solr status
 $SOLR_HOME/bin/solr create_collection -force -c cloudsuite_web_search -d cloudsuite_web_search -shards $NUM_SERVERS -p $SOLR_PORT
 
-kill -9 $(pgrep java) $(pgrep java)
+kill -9 $(pgrep java)
+
+# Wait for the process to finish.
+while kill -0 $(pgrep java); do
+  sleep 1
+done 
 
 cd $SOLR_CORE_DIR/cloudsuite_web_search*
 rm -rf data


### PR DESCRIPTION
Currently the data set is created with symbolic link, which is much faster than the original copy way. In this case, it is possible that the old Solr process is not killed (it takes time for the old Solr to release the port) before the new Solr process gets started, and the new Solr will have problem occupying the same port. 

![image](https://user-images.githubusercontent.com/8319391/218766669-4e36d336-6034-4324-92f5-b5130a1b5187.png)

This PR fixes this problem by waiting for the process to end. It has been tested locally. 