### PR TITLE
Add text editor to `base-os` ubuntu image

### DIFF
--- a/commons/base-os/Dockerfile.amd64
+++ b/commons/base-os/Dockerfile.amd64
@@ -1,3 +1,3 @@
 FROM ubuntu:22.04
-RUN apt-get update && apt-get install -y --no-install-recommends vim nano && rm -rf /var/lib/apt/lists/*;
+RUN apt-get update && apt-get install -y --no-install-recommends nano && rm -rf /var/lib/apt/lists/*;
 

--- a/commons/base-os/Dockerfile.arm64
+++ b/commons/base-os/Dockerfile.arm64
@@ -1,3 +1,3 @@
 FROM ubuntu:22.04
-RUN apt-get update && apt-get install -y --no-install-recommends vim nano && rm -rf /var/lib/apt/lists/*;
+RUN apt-get update && apt-get install -y --no-install-recommends nano && rm -rf /var/lib/apt/lists/*;
 

--- a/commons/base-os/Dockerfile.riscv64
+++ b/commons/base-os/Dockerfile.riscv64
@@ -1,4 +1,4 @@
 FROM riscv64/ubuntu:22.04
-RUN apt-get update && apt-get install -y --no-install-recommends vim nano && rm -rf /var/lib/apt/lists/*;
+RUN apt-get update && apt-get install -y --no-install-recommends nano && rm -rf /var/lib/apt/lists/*;
 
 


### PR DESCRIPTION
Sometimes we need to interact with files inside the image, I added both `nano` and `vim` to the `base-os` such as all the workloads inherit a default editor.