### PR TITLE
Remove Debian Legacy

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: build and push
         run: "./.github/scripts/build-images.sh"
         env:
-          IMG_TAG: "debian"
+          IMG_TAG: "ubuntu"
       - id: set_is_parent_modified
         run: echo "is_parent_modified=${MODIFIED}" >> $GITHUB_OUTPUT
       

--- a/benchmarks/data-caching/client/README.md
+++ b/benchmarks/data-caching/client/README.md
@@ -1,6 +1,6 @@
 # Memcached Client #
 
-This `Dockerfile` creates a debian image representing the Memcached client which tries to access server's data.
+This `Dockerfile` creates a docker image representing the Memcached client which tries to access server's data.
 
 Example:
 

--- a/benchmarks/data-caching/server/README.md
+++ b/benchmarks/data-caching/server/README.md
@@ -1,6 +1,6 @@
 # Memcached Server #
 
-This `Dockerfile` creates a debian image containing the latest version of Memcached (1.6.10).
+This `Dockerfile` creates a docker image containing the latest version of Memcached (1.6.10).
 Memcached will be started as a daemon with the passed parameters.
 Example:
 


### PR DESCRIPTION
This PR checked the appearance of the word `debian` in this project and try to replace them. At present, only the following debian-related stuff are reserved:
- `DEBIAN_FRONTEND`: This option avoid any interaction for apt, and is still useful for both Debian and Ubuntu, so I keep it.
- Cassandra and Spark have `debian` in their apt repository. I have checked the official website and this point is the correct way to do it. However, as Cassandra 4.0 gets released, their way to setup apt is different. This deserves a different PR to update the software version. 
- Keyword for Solr's client to do searching. 

This PR is also a fix to #370. 