### PR TITLE
docker: add openjdk17 to commons

### DIFF
--- a/commons/java/openjdk17/Dockerfile
+++ b/commons/java/openjdk17/Dockerfile
@@ -1,0 +1,4 @@
+FROM cloudsuite/base-os:ubuntu
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends openjdk-17-jdk-headless \
+        && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
We are updating the software stack for the analytics workloads. The newer Spark version supports up to jdk 17.