### PR TITLE
Make Solr Use OpenJDK 17 and Update Its Version

### DIFF
--- a/benchmarks/web-search/index/Dockerfile
+++ b/benchmarks/web-search/index/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -y \
 ENV BASE_PATH /usr/src
 ENV NUTCH_VERSION 1.18
 ENV NUTCH_HOME $BASE_PATH/apache-nutch-1.18
-ENV SOLR_VERSION 9.0.0
+ENV SOLR_VERSION 9.1.1
 ENV SOLR_HOME $BASE_PATH/solr-$SOLR_VERSION
 ENV PACKAGES_URL http://cloudsuite.ch/download/web_search
 ENV INDEX_URL $PACKAGES_URL/index

--- a/benchmarks/web-search/index/Dockerfile
+++ b/benchmarks/web-search/index/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudsuite/java:openjdk11
+FROM cloudsuite/java:openjdk17
 
 RUN apt-get update -y \
   && apt-get install -y --no-install-recommends procps telnet lsof wget unzip \

--- a/benchmarks/web-search/index/generate_index.sh
+++ b/benchmarks/web-search/index/generate_index.sh
@@ -1,5 +1,7 @@
 #! bin/bash
 
+export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac))))
+
 cd $NUTCH_HOME
 $NUTCH_HOME/bin/nutch generate crawl/crawldb crawl/segments -topN 100
 segLast=`ls -d crawl/segments/2* | tail -1`

--- a/benchmarks/web-search/server/Dockerfile
+++ b/benchmarks/web-search/server/Dockerfile
@@ -8,7 +8,7 @@ COPY files/limits.txt /root/.
 RUN cat /root/limits.txt >> /etc/security/limits.conf
 
 ENV BASE_PATH /usr/src
-ENV SOLR_VERSION 9.0.0
+ENV SOLR_VERSION 9.1.1
 ENV SOLR_HOME $BASE_PATH/solr-$SOLR_VERSION
 ENV PACKAGES_URL http://cloudsuite.ch/download/web_search
 ENV INDEX_URL $PACKAGES_URL/index

--- a/benchmarks/web-search/server/Dockerfile
+++ b/benchmarks/web-search/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudsuite/java:openjdk11
+FROM cloudsuite/java:openjdk17
 
 RUN apt-get update -y \
 	&& apt-get install -y --no-install-recommends procps telnet lsof wget unzip \


### PR DESCRIPTION
This PR updates the version of Solr and make it use JDK 17 for better support and functionality. 