### PR TITLE
fix bug in data-caching entrypoint

### DIFF
--- a/benchmarks/data-caching/client/docker-entrypoint.sh
+++ b/benchmarks/data-caching/client/docker-entrypoint.sh
@@ -9,6 +9,7 @@ INTERVAL=1
 GET_RATIO=0.8
 CONNECTION=200
 RPS=10000
+NEGATIVE_EXPONENTIAL=false
 
 while (( ${#@} )); do
   case ${1} in
@@ -20,6 +21,7 @@ while (( ${#@} )); do
     --g=*)       GET_RATIO=${1#*=} ;;
     --c=*)       CONNECTION=${1#*=} ;;
     --r=*)       RPS=${1#*=} ;;
+    --ne)        NEGATIVE_EXPONENTIAL=true ;;       
     *)           ARGS+=(${1}) ;;
   esac
 
@@ -49,10 +51,13 @@ elif [ "$MODE" = 'TH' ]; then
                 -g ${GET_RATIO} -w ${WORKERS} -c ${CONNECTION} -T ${INTERVAL}
 elif [ "$MODE" = 'RPS' ]; then
         echo "RPS"
+        if [ "$NEGATIVE_EXPONENTIAL" = true ]; then
+                ADDITIONA_OPTION="-e"
+        fi
         /usr/src/memcached/memcached_client/loader \
                 -a /usr/src/memcached/twitter_dataset/twitter_dataset_${SCALE}x \
                 -s /usr/src/memcached/memcached_client/docker_servers/docker_servers.txt \
-                -g ${GET_RATIO} -w ${WORKERS} -c ${CONNECTION} -T ${INTERVAL} -r ${RPS}
+                -g ${GET_RATIO} -w ${WORKERS} -c ${CONNECTION} -T ${INTERVAL} $ADDITIONA_OPTION -r ${RPS}
 elif [ "$MODE" = "bash" ]; then
         # bash
         exec /bin/bash

--- a/benchmarks/data-caching/client/docker-entrypoint.sh
+++ b/benchmarks/data-caching/client/docker-entrypoint.sh
@@ -28,8 +28,6 @@ done
 
 set -- ${ARGS[@]}
 
-echo "mode: ${MODE}, scale: ${SCALE}, workers: ${WORKERS}, server_memory: ${SERVER_MEMORY}, interval: ${INTERVAL}, get_ratio: ${GET_RATIO}, connections: ${CONNECTION}, rps: ${RPS}"
-
 if [ "$MODE" = 'S&W' ]; then
         echo "scale and warmup"
         /usr/src/memcached/memcached_client/loader \
@@ -54,7 +52,7 @@ elif [ "$MODE" = 'RPS' ]; then
         /usr/src/memcached/memcached_client/loader \
                 -a /usr/src/memcached/twitter_dataset/twitter_dataset_${SCALE}x \
                 -s /usr/src/memcached/memcached_client/docker_servers/docker_servers.txt \
-                -g ${GET_RATIO} -w ${WORKERS} -c ${CONNECTION} -T ${INTERVAL} -e -r ${RPS}
+                -g ${GET_RATIO} -w ${WORKERS} -c ${CONNECTION} -T ${INTERVAL} -r ${RPS}
 elif [ "$MODE" = "bash" ]; then
         # bash
         exec /bin/bash

--- a/docs/benchmarks/data-caching.md
+++ b/docs/benchmarks/data-caching.md
@@ -89,7 +89,7 @@ This command will run the benchmark with the maximum throughput; however, the Qo
 
     $ docker exec -it dc-client /bin/bash /entrypoint.sh --m="RPS" --S=28 --g=0.8 --c=200 --w=8 --T=1 --r=rps 
 
-where `rps` is 90% of the maximum number of requests per second achieved using the previous command. You should experiment with different values of `rps` to achieve the maximum throughput without violating the target QoS requirements.
+where `rps` is 90% of the maximum number of requests per second achieved using the previous command. You should experiment with different values of `rps` to achieve the maximum throughput without violating the target QoS requirements. By default, the request interval is fixed. You can add `--ne` to make the interval follow negative exponential distribution
 
 Note that the last two commands will continue forever if you do not stop or kill the command. For running the command for a given amount of time, you can use the timeout command. The following example will run the benchmark in the `RPS` mode for 20 seconds:
 

--- a/docs/benchmarks/data-caching.md
+++ b/docs/benchmarks/data-caching.md
@@ -89,7 +89,7 @@ This command will run the benchmark with the maximum throughput; however, the Qo
 
     $ docker exec -it dc-client /bin/bash /entrypoint.sh --m="RPS" --S=28 --g=0.8 --c=200 --w=8 --T=1 --r=rps 
 
-where `rps` is 90% of the maximum number of requests per second achieved using the previous command. You should experiment with different values of `rps` to achieve the maximum throughput without violating the target QoS requirements. By default, the request interval is fixed. You can add `--ne` to make the interval follow negative exponential distribution
+where `rps` is 90% of the maximum number of requests per second achieved using the previous command. You should experiment with different values of `rps` to achieve the maximum throughput without violating the target QoS requirements. By default, the request interval is fixed. You can add `--ne` to make the interval follow negative exponential distribution.
 
 Note that the last two commands will continue forever if you do not stop or kill the command. For running the command for a given amount of time, you can use the timeout command. The following example will run the benchmark in the `RPS` mode for 20 seconds:
 


### PR DESCRIPTION
This PR makes two changes:
It removes an unnecessary echo line in the client entry point
It changes the load generator to use fixed distribution. This way, the actual load is closer to the given RPS. 
