### PR TITLE
Fix: in memory analytics memory overriding

### DIFF
--- a/benchmarks/in-memory-analytics/latest/movielens-als/src/main/scala/MovieLensALS.scala
+++ b/benchmarks/in-memory-analytics/latest/movielens-als/src/main/scala/MovieLensALS.scala
@@ -28,8 +28,6 @@ object MovieLensALS {
 
     val conf = new SparkConf()
       .setAppName("MovieLensALS")
-      .set("spark.executor.memory", "2g")
-    println(conf)
     val sc = new SparkContext(conf)
 
     // time the execution


### PR DESCRIPTION
This PR fixes the bug that outside option `--executor-memory` does not take effect due to the internal option to fix the memory. 