### PR TITLE
set a limit for maximum concurrent clients in media streaming

### DIFF
--- a/benchmarks/media-streaming/client/files/docker-entrypoint.sh
+++ b/benchmarks/media-streaming/client/files/docker-entrypoint.sh
@@ -6,9 +6,10 @@ set -e
 # $3: the total number of sessions
 # $4: the rate (sessions per seconds)
 # $5: plain text or encrypted communication, possible values are "PT" and "TLS"
+# $6: the number of concurrent sessions
 
 if [ "$1" = "bash" ]; then
   exec $@
 else
-  cd /root/run && exec ./benchmark.sh $1 $2 $3 $4 $5
+  cd /root/run && exec ./benchmark.sh $1 $2 $3 $4 $5 $6
 fi

--- a/benchmarks/media-streaming/client/files/run/benchmark.sh
+++ b/benchmarks/media-streaming/client/files/run/benchmark.sh
@@ -5,6 +5,7 @@ num_clients_per_machine=${2:-4}
 num_sessions=${3:-100}
 rate=${4:-10}
 mode=${5:-TLS}
+num_concurrent_sessions=${6:-0}
 
 streaming_client_dir=..
 #server_ip=$(tail -n 1 hostlist.server)
@@ -16,6 +17,7 @@ peak_hunter/launch_hunt_bin.sh           \
 	$num_clients_per_machine               \
 	$num_sessions                          \
 	$rate                                  \
-  $mode
+    $mode                                  \
+    $num_concurrent_sessions
 
 ./process_logs.sh

--- a/benchmarks/media-streaming/client/files/run/peak_hunter/launch_hunt_bin.sh
+++ b/benchmarks/media-streaming/client/files/run/peak_hunter/launch_hunt_bin.sh
@@ -7,9 +7,10 @@ numClientsPerHost="$4"
 totalNumSessions="$5"
 rate="$6"
 mode="$7"
+num_concurrent_sessions="$8"
 
-if [ $# -ne 7 ]; then
-  echo "Usage: launch_hunt_bin.sh <video_server_ip> <host_list_file> <remote_output_path> <num_clients_per_host> <total_num_sessions> <rate> <encryption_mode>"
+if [ $# -ne 8 ]; then
+  echo "Usage: launch_hunt_bin.sh <video_server_ip> <host_list_file> <remote_output_path> <num_clients_per_host> <total_num_sessions> <rate> <encryption_mode> <num_concurrent_sessions>"
   exit 
 fi
 
@@ -34,7 +35,7 @@ function launchRemote () {
   totalErrors=0
   
   numSessions="$1"
-  $(dirname $0)/launch_remote.sh $videoServerIp $hostFileName $remoteOutputPath $numClientsPerHost $numSessions $rate $mode
+  $(dirname $0)/launch_remote.sh $videoServerIp $hostFileName $remoteOutputPath $numClientsPerHost $numSessions $rate $mode $num_concurrent_sessions
   if [ $? -ne 0 ]; then
     echo 'Failed launching remote... exiting.'
     exit

--- a/benchmarks/media-streaming/client/files/run/peak_hunter/launch_remote.sh
+++ b/benchmarks/media-streaming/client/files/run/peak_hunter/launch_remote.sh
@@ -7,9 +7,10 @@ numClientsPerHost="$4"
 numSessions="$5"
 rate="$6"
 mode="$7"
+num_concurrent_sessions="$8"
 
-if [ $# -ne 7 ]; then
-  echo "Usage: launch_remote.sh <video_server_ip> <host_list_file> <remote_output_path> <num_clients_per_host> <num_sessions> <rate> <encryption_mode>"
+if [ $# -ne 8 ]; then
+  echo "Usage: launch_remote.sh <video_server_ip> <host_list_file> <remote_output_path> <num_clients_per_host> <num_sessions> <rate> <encryption_mode> <num_concurrent_sessions>"
   exit 
 fi
 
@@ -34,7 +35,7 @@ do
 	echo "Launching $numClientsPerHost clients on $host";
 	for i in $(seq 1 $numClientsPerHost)
 	do
-	cmd="httperf --hog --server $videoServerIp --videosesslog=[$logs],[0.1,0.3,0.4,0.2],[localhost,localhost,localhost,localhost] --epoll --recv-buffer=524288 $mode --output-log=/output/result$i.log --num-sessions=$numSessions --rate=$rate 2>>/output/bt$i.trace" # > output-stdout/stdout$i"
+	cmd="httperf --hog --server $videoServerIp --videosesslog=[$logs],[0.1,0.3,0.4,0.2],[localhost,localhost,localhost,localhost] --epoll --recv-buffer=524288 $mode --output-log=/output/result$i.log --num-sessions=$numSessions --rate=$rate --num-concurrent-sessions=$num_concurrent_sessions 2>>/output/bt$i.trace" # > output-stdout/stdout$i"
 	echo "Running command $cmd"
 	eval $cmd &
 	done 

--- a/benchmarks/media-streaming/client/files/videoperf/gen/videosesslog.c
+++ b/benchmarks/media-streaming/client/files/videoperf/gen/videosesslog.c
@@ -366,7 +366,11 @@ sess_create (Any_Type arg)
   double random_val = 0.0;
   int i = 0;
   int session_log_index = -1;
-
+  
+  int concurrent_sessions = num_sessions_generated - num_sessions_destroyed;
+  if (param.num_concurrent_sessions && concurrent_sessions >= param.num_concurrent_sessions){
+    return 0;  
+  }
   if (num_sessions_generated++ >= param.num_sessions) {
     //core_exit();
     return -1;

--- a/benchmarks/media-streaming/client/files/videoperf/httperf.c
+++ b/benchmarks/media-streaming/client/files/videoperf/httperf.c
@@ -171,6 +171,7 @@ static struct option longopts[] =
   {"videosesslog",     required_argument, (void *) &param.videosesslog,	0},
   {"num-sessions",     required_argument, (void *) &param.num_sessions, 0},
   {"output-log",   required_argument, (void *) &param.output_log,	0},
+  {"num-concurrent-sessions", required_argument, (void *)&param.num_concurrent_sessions, 0},
   {0,		     0,			0,				0}
 };
 
@@ -369,6 +370,7 @@ main (int argc, char **argv)
   param.ssl_reuse = 1;
 #endif
   param.num_sessions = 0;
+  param.num_concurrent_sessions = 0;
 
   /* get program name: */
   prog_name = strrchr (argv[0], '/');
@@ -1059,6 +1061,10 @@ skip_local_ip_param:
 else if (flag == &param.num_sessions)
 {
   param.num_sessions = strtoul (optarg, &end, 0);	
+}
+else if (flag == &param.num_concurrent_sessions)
+{
+  param.num_concurrent_sessions = strtoul (optarg, &end, 0);
 }
 /*
    else if (flag == &param.wset)

--- a/benchmarks/media-streaming/client/files/videoperf/httperf.h
+++ b/benchmarks/media-streaming/client/files/videoperf/httperf.h
@@ -237,6 +237,7 @@ typedef struct Cmdline_Params
 	} 
 	videosesslog;
 	u_int num_sessions;				/* # of user-sessions */
+    u_int num_concurrent_sessions;  /* # of concurrent sessions */
 }
 Cmdline_Params;
 

--- a/docs/benchmarks/media-streaming.md
+++ b/docs/benchmarks/media-streaming.md
@@ -73,7 +73,7 @@ Then, you can use any command (e.g., `scp`, `rsync`) to transfer files to the cl
 To run the client container, use the following command:
 
 ```bash
-$ docker run -t --name=streaming_client -v <lists>:/videos/logs -v <results>:/output --net host cloudsuite/media-streaming:client ${SERVER_IP} ${VIDEOPERF_PROCESSES} ${VIDEO_COUNT} ${RATE} ${ENCRYPTION_MODE}
+$ docker run -t --name=streaming_client -v <lists>:/videos/logs -v <results>:/output --net host cloudsuite/media-streaming:client ${SERVER_IP} ${VIDEOPERF_PROCESSES} ${VIDEO_COUNT} ${RATE} ${ENCRYPTION_MODE} ${NUM_CONCURRENT_SESSIONS}
 ```
 
 Parameters are:
@@ -84,6 +84,7 @@ Parameters are:
 - `VIDEO_COUNT`: The total number of videos to request. Each video is represented by one session from the `session list`, and the client requests the video by sending HTTP queries to get video chunks sequentially. 
 - `RATE`: The rate (videos per second) for new video request generation. 
 - `ENCRYPTION_MODE`: Whether the transfer is encrypted or not. Possible values are "PT", which stands for plain text; and "TLS", which enables TLS v1.3.
+- `NUM_CONCURRENT_SESSIONS`: The maximum number of clients able to concurrently stream videos from the server. If left unspecified or set to zero, there will be no limit on the number of concurrent clients.
 
 #### Note for Video Request Generation
 


### PR DESCRIPTION
This PR adds the feature to the Media Streaming benchmark to limit the number of concurrent clients. 
It would be useful to control the throughput of the benchmark because, without this feature, throughput can keep increasing without any limit until it touches the network bandwidth or the computational capability of the server. 